### PR TITLE
Add feature packs to configure script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#. "$(dirname "$0")/_/husky.sh"
 
 [ -n "$CI" ] && exit 0
 

--- a/configure-package.d.ts
+++ b/configure-package.d.ts
@@ -1,0 +1,18 @@
+export type Feature = {
+    info: {
+        name: string;
+        description: string;
+        prompt: string;
+    };
+    packages: {
+        dependencies: {
+            [key: string]: string;
+        };
+        devDependencies: {
+            [key: string]: string;
+        };
+    };
+    scripts: {
+        [key: string]: string;
+    };
+};

--- a/configure-package.js
+++ b/configure-package.js
@@ -587,7 +587,7 @@ function removeFeaturesDirectory() {
 function copyDirectory(src, dest, ignores = []) {
     // Create destination directory if it doesn't exist
     if (!fs.existsSync(dest)) {
-        //fs.mkdirSync(dest);
+        fs.mkdirSync(dest);
     }
 
     const files = fs.readdirSync(src);
@@ -776,21 +776,21 @@ class FeaturePacks {
 
     /** @param {import('./configure-package.d.ts').Feature} feature */
     addFeature(feature) {
-        // const pkg = new PackageFile();
+        const pkg = new PackageFile();
 
-        // for (const script in feature.scripts) {
-        //     pkg.addScript(script, feature.scripts[script]);
-        // }
+        for (const script in feature.scripts) {
+            pkg.addScript(script, feature.scripts[script]);
+        }
 
-        // pkg.save();
+        pkg.save();
 
-        // if (Object.values(feature.packages.dependencies).length) {
-        //     runCommand(`npm install ${feature.packages.dependencies.join(' ')}`, { cwd: __dirname, stdio: 'inherit' });
-        // }
+        if (Object.values(feature.packages.dependencies).length) {
+            runCommand(`npm install ${feature.packages.dependencies.join(' ')}`, { cwd: __dirname, stdio: 'inherit' });
+        }
 
-        // if (Object.values(feature.packages.devDependencies).length) {
-        //     runCommand(`npm install ${feature.packages.devDependencies.join(' ')} -D`, { cwd: __dirname, stdio: 'inherit' });
-        // }
+        if (Object.values(feature.packages.devDependencies).length) {
+            runCommand(`npm install ${feature.packages.devDependencies.join(' ')} -D`, { cwd: __dirname, stdio: 'inherit' });
+        }
 
         copyDirectory(feature.path, __dirname, [feature.featureScript]);
     }
@@ -828,9 +828,6 @@ const lintAndFormatSourceFiles = () => {
 };
 
 const run = async function () {
-    await new FeaturePacks().run();
-    process.exit(0);
-
     await populatePackageInfo();
     await configureOptionalFeatures();
 
@@ -870,6 +867,7 @@ const run = async function () {
     try {
         console.log('Done, removing this script.');
         fs.unlinkSync(__filename);
+        fs.unlinkSync('./configure-package.d.ts');
     } catch (e) {
         console.log('Error removing script: ', e);
     }

--- a/features/serverless/feature.js
+++ b/features/serverless/feature.js
@@ -4,22 +4,34 @@ const getServerlessPort = name => {
     return 3000 + (hash % 7000) + portAddition;
 };
 
-const packages = [
-    'serverless',
-    'serverless-api-compression',
-    'serverless-prune-plugin',
-    'serverless-offline',
-    'serverless-bundle'
-];
+const info = {
+    name: 'serverless',
+    description: 'Serverless framework',
+    prompt: 'Do you want to use the serverless framework?',
+};
+
+const packages = {
+    /** @type string[] */
+    dependencies: [],
+    /** @type string[] */
+    devDependencies: [
+        'serverless',
+        'serverless-api-compression',
+        'serverless-prune-plugin',
+        'serverless-offline',
+        'serverless-bundle'
+    ],
+};
 
 const scripts = {
     'serve:dev': `serverless offline start --httpPort ${getServerlessPort('{{package.name}}')}`,
     deploy: 'serverless deploy',
 };
 
-module.exports = {
+const feature = {
+    info,
     packages,
     scripts,
 };
 
-console.log(scripts);
+module.exports = {feature,};

--- a/features/serverless/feature.js
+++ b/features/serverless/feature.js
@@ -1,0 +1,25 @@
+const getServerlessPort = name => {
+    const hash = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    const portAddition = (Math.floor(Math.random() * 9) + 1) * 100;
+    return 3000 + (hash % 7000) + portAddition;
+};
+
+const packages = [
+    'serverless',
+    'serverless-api-compression',
+    'serverless-prune-plugin',
+    'serverless-offline',
+    'serverless-bundle'
+];
+
+const scripts = {
+    'serve:dev': `serverless offline start --httpPort ${getServerlessPort('{{package.name}}')}`,
+    deploy: 'serverless deploy',
+};
+
+module.exports = {
+    packages,
+    scripts,
+};
+
+console.log(scripts);

--- a/features/serverless/serverless.yml
+++ b/features/serverless/serverless.yml
@@ -1,0 +1,57 @@
+frameworkVersion: '3'
+
+service: '{{package.name}}'
+app: '{{package.name}}'
+org: '{{package.vendor.github}}'
+
+provider:
+  name: aws
+  runtime: nodejs16.x
+  stage: dev
+  region: us-east-1
+  timeout: 10
+  deploymentMethod: direct
+  versionFunctions: false
+  httpApi:
+    cors: true
+  apiGateway:
+    minimumCompressionSize: 1024
+
+package:
+  patterns:
+    - '!./**'
+    - ./src/**
+  individually: false
+  excludeDevDependencies: true
+
+plugins:
+  - serverless-api-compression
+  - serverless-prune-plugin
+  - serverless-offline
+  - serverless-bundle
+
+custom:
+  bundle:
+    sourcemaps: false
+    linting: false
+    disableForkTsChecker: true
+    stats: false
+  prune:
+    automatic: true
+    number: 2
+  contentCompression: 1024
+
+functions:
+  get-users:
+    handler: src/handlers/get-users.handler
+    events:
+      - httpApi:
+          path: /users
+          method: GET
+
+  get-articles:
+    handler: src/handlers/get-articles.handler
+    events:
+      - httpApi:
+          path: /articles
+          method: GET

--- a/features/serverless/src/handlers/get-articles.ts
+++ b/features/serverless/src/handlers/get-articles.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function handler(event: any, context: any) {
+    const body = JSON.stringify({
+        articles: [
+            {
+                id: '1',
+                title: 'Article 1',
+                content: 'Article 1 content',
+            },
+            {
+                id: '2',
+                title: 'Article 2',
+                content: 'Article 2 content',
+            },
+        ],
+    });
+
+    const headers = {'content-length': body.length,};
+
+    return { body, headers, statusCode: 200 };
+}

--- a/features/serverless/src/handlers/get-users.ts
+++ b/features/serverless/src/handlers/get-users.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export async function handler(event: any, context: any) {
+    const body = JSON.stringify({
+        users: [
+            {
+                id: '1',
+                name: 'User 1',
+                email: 'user1@example.com',
+            },
+            {
+                id: '2',
+                name: 'User 2',
+                email: 'user2@example.com',
+            },
+        ],
+    });
+
+    const headers = {'content-length': body.length,};
+
+    return { body, headers, statusCode: 200 };
+}


### PR DESCRIPTION
Adds support for "feature packs" in the configure script by handling the `features` directory.  Each subdirectory in `features` must have a `feature.js` file that exports a `feature` object that has the following shape:

```ts
type Feature = {
    info: {
        name: string;
        description: string;
        prompt: string;
    };
    packages: {
        dependencies: {
            [key: string]: string;
        };
        devDependencies: {
            [key: string]: string;
        };
    };
    scripts: {
        [key: string]: string;
    };
};
``` 