### PR TITLE
Fix bug in configure script

### DIFF
--- a/configure-package.js
+++ b/configure-package.js
@@ -441,7 +441,7 @@ const populatePackageInfo = async (onlyEmpty = false) => {
     // check if the guessed vendor is a github org, and if so, use the org name
     const orgResponse = await getGithubApiEndpoint(`orgs/${packageInfo.vendor.github}`);
     if (orgResponse.exists) {
-        packageInfo.vendor.name = orgResponse.data.name;
+        packageInfo.vendor.name = orgResponse.data.name ?? orgResponse.data.login;
     }
 
     await conditionalAsk(packageInfo, 'name', onlyEmpty, 'package name?', false);


### PR DESCRIPTION
This PR fixes a bug in the configure script when the owning organization does not have a name associated with it, causing an exception. This is now fixed and defaults to the organization login name instead.